### PR TITLE
Trainer: add Dynamic Difficulty Slider

### DIFF
--- a/dllmain/Settings.h
+++ b/dllmain/Settings.h
@@ -196,6 +196,8 @@ public:
 	bool bTrainerAllowEnterDoorsWithoutAsh = false;
 	bool bTrainerEnableDebugTrg = false;
 	bool bTrainerShowDebugTrgHintText = true;
+	bool bTrainerOverrideDynamicDifficulty = false;
+	int iTrainerDynamicDifficultyLevel = 5;
 
 	// WARNING
 	bool bIgnoreFPSWarning = false;

--- a/dllmain/Trainer.cpp
+++ b/dllmain/Trainer.cpp
@@ -728,7 +728,7 @@ void Trainer_Init()
 				{
 					GlobalPtr()->dynamicDifficultyPoints_4F94 = pConfig->iTrainerDynamicDifficultyLevel * 1000 + 500;
 					// update the edx register for the coming DynamicDifficultyLevel assignment
-					regs.edx = (int)((unsigned __int64)(0x10624DD3i64 * GlobalPtr()->dynamicDifficultyPoints_4F94 >> 0x20)) >> 6;
+					regs.edx = (uint32_t)(GlobalPtr()->dynamicDifficultyPoints_4F94 / 1000);
 				}
 
 				// Code that we overwrote
@@ -743,10 +743,9 @@ void Trainer_Init()
 			void operator()(injector::reg_pack& regs)
 			{
 				if (pConfig->bTrainerOverrideDynamicDifficulty)
-					regs.ef |= (1 << regs.zero_flag); // set the zero flag so we exit the switch through the VERYEASY case
-
-				// Code that we overwrote
-				__asm {movzx eax, byte ptr[ecx + 0x847C]}
+					regs.eax = uint32_t(GameDifficulty::VeryEasy); // exit switch through VERYEASY case
+				else
+					regs.eax = *(uint8_t*)(regs.ecx + 0x847C); // orig code we overwrote
 			}
 		}; injector::MakeInline<ProfessionalModeOverride>(pattern.count(1).get(0).get<uint32_t>(0), pattern.count(1).get(0).get<uint32_t>(7));
 	}

--- a/dllmain/Trainer.cpp
+++ b/dllmain/Trainer.cpp
@@ -736,14 +736,14 @@ void Trainer_Init()
 			}
 		}; injector::MakeInline<DynamicDifficultyOverride>(pattern.count(1).get(0).get<uint32_t>(0), pattern.count(1).get(0).get<uint32_t>(7));
 
-		// Professional mode exits GameAddPoint early, so we need to take a different route through the switch at 63B22E
+		// Hook the gameDifficulty switch to prevent Professional mode from returning out of GameAddPoint early
 		pattern = hook::pattern("0F B6 81 7C 84 00 00 48 74 2F");
 		struct ProfessionalModeOverride
 		{
 			void operator()(injector::reg_pack& regs)
 			{
 				if (pConfig->bTrainerOverrideDynamicDifficulty)
-					regs.ef |= (1 << regs.zero_flag); // set the zero flag so we exit the switch early through the VERYEASY case
+					regs.ef |= (1 << regs.zero_flag); // set the zero flag so we exit the switch through the VERYEASY case
 
 				// Code that we overwrote
 				__asm {movzx eax, byte ptr[ecx + 0x847C]}

--- a/dllmain/Trainer.cpp
+++ b/dllmain/Trainer.cpp
@@ -728,6 +728,16 @@ void Trainer_Update()
 	if (!player)
 		return;
 
+	// Handle the Dynamic Difficulty Level override
+	// currently only works in normal mode and Separate Ways
+	// https://residentevil.fandom.com/wiki/Game_Rank_(RE4)
+	if (pConfig->bTrainerOverrideDynamicDifficulty)
+	{
+		GlobalPtr()->dynamicDifficultyPoints_4F94 = pConfig->iTrainerDynamicDifficultyLevel * 1000 + 500;
+		// professional mode assigns this directly, so we might have to as well
+		//GlobalPtr()->dynamicDifficultyLevel_4F98 = pConfig->iTrainerDynamicDifficultyLevel;
+	}
+
 	// Player speed override handling
 	{
 		static bool prev_bPlayerSpeedOverride = false;
@@ -1538,6 +1548,26 @@ void Trainer_RenderUI(int columnCount)
 					pConfig->fTrainerPlayerSpeedOverride = 1.0f;
 					pConfig->HasUnsavedChanges = true;
 				}
+				ImGui::EndDisabled();
+			}
+
+			// Dynamic Difficulty Slider
+			{
+				ImGui_ColumnSwitch();
+
+				ImGui::Checkbox("Enable Difficulty Level Override", &pConfig->bTrainerOverrideDynamicDifficulty);
+
+				ImGui_ItemSeparator();
+
+				ImGui::Dummy(ImVec2(10, 10 * esHook._cur_monitor_dpi));
+
+				ImGui::TextWrapped("Allows overriding the dynamic difficulty level.");
+				ImGui::TextWrapped("(Effects enemy health, damage, speed, and aggression)");
+
+				ImGui::Spacing();
+
+				ImGui::BeginDisabled(!pConfig->bTrainerOverrideDynamicDifficulty);
+				ImGui::SliderInt("", &pConfig->iTrainerDynamicDifficultyLevel, 1, 10);
 				ImGui::EndDisabled();
 			}
 

--- a/dllmain/Trainer.cpp
+++ b/dllmain/Trainer.cpp
@@ -728,7 +728,7 @@ void Trainer_Init()
 				{
 					GlobalPtr()->dynamicDifficultyPoints_4F94 = pConfig->iTrainerDynamicDifficultyLevel * 1000 + 500;
 					// update the edx register for the coming DynamicDifficultyLevel assignment
-					regs.edx = (uint32_t)(GlobalPtr()->dynamicDifficultyPoints_4F94 / 1000);
+					regs.edx = (uint32_t)(pConfig->iTrainerDynamicDifficultyLevel);
 				}
 
 				// Code that we overwrote


### PR DESCRIPTION
Currently works in normal mode and Separate Ways. Doesn't work in Assignment Ada, Mercs mode, or professional.

Like I said in the PR thread, the modes with fixed difficulties instantly reset `dynamicDifficultyPoints` whenever you attempt to modify it. Updating the value via `Trainer_Update()` manages to give the superficial impression that the difficulty is being overriden in the globals panel, but the game's logic is still updating according to the internal difficulty setting. You can test this by starting up Assignment Ada, setting the difficulty override to 1, and seeing how much damage you take vs how much damage you take with the `SYS_OMAKE_ADA_GAME` flag disabled (this disables the internal override).

Additionally, professional mode sets `dynamicDifficultyLevel` directly to 10, which is a redundancy to keep in mind. This is all handled in the `GameAddPoint` function of bio4-110.c:. For example, this is what sets Assignment Ada's `dynamicDifficultyPoints` to 4500, or 6500 if you're in room 40E (Krauser boss fight):
```cpp
if ( (v8->Flags_SYSTEM_0_54[0] & 0x80000000) != 0 )
  {
    if ( pSys->language_8 == 1 || (v8->dynamicDifficultyPoints_4F94 = 0x1194, v8 = pG, pG->curRoomId_4FAC == 0x40E) )
    {
      v8->dynamicDifficultyPoints_4F94 = 0x1964;
      v8 = pG;
    }
  }
```

It would be good if you could work your magic to help finish this, or point me to a resource to get started with finding addresses and injecting.