### PR TITLE
Misc: added NTSC mode

### DIFF
--- a/dllmain/60fpsFixes.cpp
+++ b/dllmain/60fpsFixes.cpp
@@ -189,7 +189,7 @@ void Init_60fpsFixes()
 				}
 
 				if (!waiting && !cameraLocked)
-					regs.ef |= (1 << regs.zero_flag);
+					regs.ef |= (1 << regs.zero_flag); // proceed through the function
 				else
 					regs.ef &= ~(1 << regs.zero_flag);
 			}

--- a/dllmain/Misc.cpp
+++ b/dllmain/Misc.cpp
@@ -1121,41 +1121,47 @@ void Init_Misc()
 			pattern = hook::pattern("A1 40 ? ? ? 80 ? ? 00 74 ? 6A 0E");
 			injector::MakeNOP(pattern.count(1).get(0).get<uint32_t>(9), 2); // R400Main()
 
-			// remove Easy Mode from the title menu
-			pattern = hook::pattern("A1 40 ? ? ? 80 78 ? 01 74");
-			if (!pattern.empty())
+			// remove Easy Mode from the difficulty menu
+			pattern = hook::pattern("A1 40 ? ? ? 80 78 ? 01 75");
+			injector::MakeNOP(pattern.count(1).get(0).get<uint32_t>(9), 2); // titleLevelInit
+
+			// skip difficulty select on a New Game save
+			pattern = hook::pattern("B8 04 00 00 00 5B 8B E5");
+			struct SkipLevelSelect
 			{
-				// these seem to handle menu input control
-				Patch(pattern.count(1).get(0).get<uint32_t>(9), { 0xEB }); // titleMain:sub_6D6010, jz -> jmp
-
-				pattern = hook::pattern("80 78 ? 01 53 74 ");
-				Patch(pattern.count(1).get(0).get<uint32_t>(10), { 0xEB }); // titleLevelSelect, jz -> jmp
-
-				// this is what hides the menu texture
-				pattern = hook::pattern("A1 40 ? ? ? 80 78 ? 01 75");
-				injector::MakeNOP(pattern.count(1).get(0).get<uint32_t>(9), 2); // titleLevelInit
-
-				// skip level select on a New Game save
-				pattern = hook::pattern("B8 04 00 00 00 5B 8B E5");
-				struct SkipLevelSelect
+				void operator()(injector::reg_pack& regs)
 				{
-					void operator()(injector::reg_pack& regs)
-					{
-						bool NewGame = !FlagIsSet(SystemSavePtr()->flags_EXTRA_4, uint32_t(Flags_EXTRA::EXT_HARD_MODE));
-						regs.eax = NewGame ? 1 : 4;
-					}
-				}; injector::MakeInline<SkipLevelSelect>(pattern.count(1).get(0).get<uint32_t>(0), pattern.count(1).get(0).get<uint32_t>(5));
-			}
-			/*
-			else // these checks are reversed in the JP.exe for some reason
-			{
-				pattern = hook::pattern("A1 40 ? ? ? 80 78 ? 00 53 75");
-				Patch(pattern.count(1).get(0).get<uint32_t>(10), { 0xEB }); // titleMain:sub_6D6010, jnz -> jmp
+					bool newGame = !FlagIsSet(SystemSavePtr()->flags_EXTRA_4, uint32_t(Flags_EXTRA::EXT_HARD_MODE));
+					regs.eax = newGame ? uint32_t(TitleCommand::Start) : uint32_t(TitleCommand::Level);
+				}
+			}; injector::MakeInline<SkipLevelSelect>(pattern.count(1).get(0).get<uint32_t>(0), pattern.count(1).get(0).get<uint32_t>(5));
 
-				pattern = hook::pattern("89 4E ? A1 40 ? ? ? 80");
-				Patch(pattern.count(1).get(0).get<uint32_t>(12), { 0xEB }); // titleLevelSelect, jnz -> jmp
+			// special handling for the JP.exe title menu
+			pattern = hook::pattern("A1 40 ? ? ? 80 78 ? 01 74");
+			if (pattern.empty())
+			{
+				// hijack the 'if (!(pSys->flags_EXTRA_4[0] & EXT_HARD_MODE))' block to hide Amateur mode instead
+				pattern = hook::pattern("C7 46 30 01 00 00 00");
+				injector::MakeNOP(pattern.count(1).get(0).get<uint32_t>(7), 2); // titleLevelInit
+				injector::MakeNOP(pattern.count(1).get(0).get<uint32_t>(16), 2);
+				Patch(pattern.count(1).get(0).get<uint32_t>(21), { 0x09 });
+				Patch(pattern.count(1).get(0).get<uint32_t>(38), { 0x0A });
+				// erase the rest of the block
+				pattern = hook::pattern("C7 46 ? 03 00 00 00 85 DB");
+				injector::MakeNOP(pattern.get_first(0), 37);
+
+				// disable the JP difficulty select confirmation prompts
+				pattern = hook::pattern("A1 40 ? ? ? 38 58 08 75");
+				Patch(pattern.count(1).get(0).get<uint32_t>(8), { 0xEB }); // titleMain, jnz -> jmp
+
+				// ignore pSys->language_8 check when skipping the difficulty menu
+				pattern = hook::pattern("38 59 08 0F 84 09 0B 00 00");
+				injector::MakeNOP(pattern.count(1).get(0).get<uint32_t>(3), 6); // titleMain, jz -> jmp
 			}
-			*/
+
+			// remove JP only 20% damage mitigation armor from Assignment Ada
+			pattern = hook::pattern("F7 46 54 00 00 00 40");
+			Patch(pattern.count(1).get(0).get<uint32_t>(7), { 0xEB }); // LifeDownSet2, jz -> jmp
 		}
 	}
 

--- a/dllmain/Misc.cpp
+++ b/dllmain/Misc.cpp
@@ -1121,7 +1121,7 @@ void Init_Misc()
 			pattern = hook::pattern("A1 40 ? ? ? 80 ? ? 00 74 ? 6A 0E");
 			injector::MakeNOP(pattern.count(1).get(0).get<uint32_t>(9), 2); // R400Main()
 
-			// remove Easy Mode from the difficulty menu
+			// remove Easy mode from the difficulty menu
 			pattern = hook::pattern("A1 40 ? ? ? 80 78 ? 01 75");
 			injector::MakeNOP(pattern.count(1).get(0).get<uint32_t>(9), 2); // titleLevelInit
 
@@ -1140,7 +1140,7 @@ void Init_Misc()
 			pattern = hook::pattern("A1 40 ? ? ? 80 78 ? 01 74");
 			if (pattern.empty())
 			{
-				// hijack the 'if (!(pSys->flags_EXTRA_4[0] & EXT_HARD_MODE))' block to hide Amateur mode instead
+				// override the hide Professional mode block to hide Amateur mode instead
 				pattern = hook::pattern("C7 46 30 01 00 00 00");
 				injector::MakeNOP(pattern.count(1).get(0).get<uint32_t>(7), 2); // titleLevelInit
 				injector::MakeNOP(pattern.count(1).get(0).get<uint32_t>(16), 2);

--- a/dllmain/Misc.cpp
+++ b/dllmain/Misc.cpp
@@ -1116,22 +1116,34 @@ void Init_Misc()
 			pattern = hook::pattern("8B 15 ? ? ? ? 80 7A ? 01 74");
 			Patch(pattern.count(2).get(1).get<uint32_t>(10), { 0xEB }); // shootResult, jz -> jmp
 
-			// Mercenaries: unlock Village stage difficulty, requires 60fps fix
+			// Mercenaries: unlock village stage difficulty, requires 60fps fix
 			Patch(pattern.count(2).get(0).get<uint32_t>(10), { 0xEB }); // GameAddPoint, jz -> jmp
 			pattern = hook::pattern("A1 40 ? ? ? 80 ? ? 00 74 ? 6A 0E");
 			injector::MakeNOP(pattern.count(1).get(0).get<uint32_t>(9), 2); // R400Main()
 
+			/*
 			// remove Easy Mode from the title menu
 			pattern = hook::pattern("A1 40 ? ? ? 80 78 ? 01 75");
 			injector::MakeNOP(pattern.count(1).get(0).get<uint32_t>(9), 2); // titleLevelInit
 
-			// don't know what this does, but it's also unlocked by having professional mode unlocked, so probably not language related
+			// this stuff looks like it's necessary to make inputs work correctly on the difficulty select menu
 			pattern = hook::pattern("A1 40 ? ? ? 80 78 ? 01 74");
-			Patch(pattern.count(1).get(0).get<uint32_t>(9), { 0xEB }); // titleMain:sub_6D6010, jz -> jmp
+			if (!pattern.empty())
+			{
+				Patch(pattern.count(1).get(0).get<uint32_t>(9), { 0xEB }); // titleMain:sub_6D6010, jz -> jmp
 
-			// don't know what this does, but it looks similar to the previous check
-			pattern = hook::pattern("80 78 ? 01 53 74 ");
-			Patch(pattern.count(1).get(0).get<uint32_t>(10), { 0xEB }); // titleLevelSelect, jz -> jmp
+				pattern = hook::pattern("80 78 ? 01 53 74 ");
+				Patch(pattern.count(1).get(0).get<uint32_t>(10), { 0xEB }); // titleLevelSelect, jz -> jmp
+			}
+			else // these checks are reversed in the JP.exe for some reason
+			{
+				pattern = hook::pattern("A1 40 ? ? ? 80 78 ? 00 53 75");
+				Patch(pattern.count(1).get(0).get<uint32_t>(10), { 0xEB }); // titleMain:sub_6D6010, jnz -> jmp
+
+				pattern = hook::pattern("89 4E ? A1 40 ? ? ? 80");
+				Patch(pattern.count(1).get(0).get<uint32_t>(12), { 0xEB }); // titleLevelSelect, jnz -> jmp
+			}
+			*/
 		}
 	}
 

--- a/dllmain/SDK/global.h
+++ b/dllmain/SDK/global.h
@@ -69,20 +69,6 @@ enum class GameDifficulty : uint8_t
 	Pro = 0x6,
 };
 
-enum class TitleCommand : uint8_t
-{
-	Null,
-	Start,
-	Load,
-	Option,
-	Level,
-	Language,
-	Extra,
-	Leaderboards,
-	Credits,
-	QuitGame
-};
-
 enum class LeonCostume : uint8_t
 {
 	Jacket,

--- a/dllmain/SDK/global.h
+++ b/dllmain/SDK/global.h
@@ -69,6 +69,20 @@ enum class GameDifficulty : uint8_t
 	Pro = 0x6,
 };
 
+enum class TitleCommand : uint8_t
+{
+	Null,
+	Start,
+	Load,
+	Option,
+	Level,
+	Language,
+	Extra,
+	Leaderboards,
+	Credits,
+	QuitGame
+};
+
 enum class LeonCostume : uint8_t
 {
 	Jacket,

--- a/dllmain/SDK/title.h
+++ b/dllmain/SDK/title.h
@@ -66,3 +66,19 @@ struct __declspec(align(4)) TITLE_WORK
 	}
 };
 assert_size(TITLE_WORK, 0xBC);
+
+enum class TitleCommand : int32_t
+{
+	Null,
+	Start,
+	Load,
+	Option,
+	Level,
+	Language,
+	Extra,
+	Leaderboards,
+	Credits,
+	QuitGame
+};
+
+

--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -920,7 +920,7 @@ void Config::LogSettings()
 	spd::log()->info("| {:<30} | {:>15} |", "FixTurningSpeed", pConfig->bFixTurningSpeed ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "FixQTE", pConfig->bFixQTE ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "FixAshleyBustPhysics", pConfig->bFixAshleyBustPhysics ? "true" : "false");
-	spd::log()->info("| {:<30} | {:>15} |", "EnableNTSCMode", pConfig->bEnableNTSCMode ? "true" : "false");
+	spd::log()->info("| {:<30} | {:>15} |", "FixMercsMode", pConfig->bFixMercsMode ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "EnableFastMath", pConfig->bEnableFastMath ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "PrecacheModels", pConfig->bPrecacheModels ? "true" : "false");
 	spd::log()->info("+--------------------------------+-----------------+");

--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -266,6 +266,7 @@ void Config::ReadSettings(std::string_view ini_path)
 	pConfig->bFixTurningSpeed = iniReader.ReadBoolean("FRAME RATE", "FixTurningSpeed", pConfig->bFixTurningSpeed);
 	pConfig->bFixQTE = iniReader.ReadBoolean("FRAME RATE", "FixQTE", pConfig->bFixQTE);
 	pConfig->bFixAshleyBustPhysics = iniReader.ReadBoolean("FRAME RATE", "FixAshleyBustPhysics", pConfig->bFixAshleyBustPhysics);
+	pConfig->bFixMercsMode = iniReader.ReadBoolean("FRAME RATE", "FixMercsMode", pConfig->bFixMercsMode);
 	pConfig->bEnableFastMath = iniReader.ReadBoolean("FRAME RATE", "EnableFastMath", pConfig->bEnableFastMath);
 	pConfig->bPrecacheModels = iniReader.ReadBoolean("FRAME RATE", "PrecacheModels", pConfig->bPrecacheModels);
 
@@ -309,6 +310,7 @@ void Config::ReadSettings(std::string_view ini_path)
 			iCostumeComboAda--;
 	}
 
+	pConfig->bEnableNTSCMode = iniReader.ReadBoolean("MISC", "EnableNTSCMode", pConfig->bEnableNTSCMode);
 	pConfig->bAshleyJPCameraAngles = iniReader.ReadBoolean("MISC", "AshleyJPCameraAngles", pConfig->bAshleyJPCameraAngles);
 	pConfig->iViolenceLevelOverride = iniReader.ReadInteger("MISC", "ViolenceLevelOverride", pConfig->iViolenceLevelOverride);
 	pConfig->iViolenceLevelOverride = min(max(pConfig->iViolenceLevelOverride, -1), 2); // limit between -1 to 2
@@ -753,6 +755,7 @@ void WriteSettings(std::string_view iniPath, bool trainerIni)
 	iniReader.WriteBoolean("FRAME RATE", "FixTurningSpeed", pConfig->bFixTurningSpeed);
 	iniReader.WriteBoolean("FRAME RATE", "FixQTE", pConfig->bFixQTE);
 	iniReader.WriteBoolean("FRAME RATE", "FixAshleyBustPhysics", pConfig->bFixAshleyBustPhysics);
+	iniReader.WriteBoolean("FRAME RATE", "FixMercsMode", pConfig->bFixMercsMode);
 	iniReader.WriteBoolean("FRAME RATE", "EnableFastMath", pConfig->bEnableFastMath);
 	iniReader.WriteBoolean("FRAME RATE", "PrecacheModels", pConfig->bPrecacheModels);
 
@@ -762,6 +765,7 @@ void WriteSettings(std::string_view iniPath, bool trainerIni)
 	iniReader.WriteString("MISC", "LeonCostume", " " + std::string(sLeonCostumeNames[iCostumeComboLeon]));
 	iniReader.WriteString("MISC", "AshleyCostume", " " + std::string(sAshleyCostumeNames[iCostumeComboAshley]));
 	iniReader.WriteString("MISC", "AdaCostume", " " + std::string(sAdaCostumeNames[iCostumeComboAda]));
+	iniReader.WriteBoolean("MISC", "EnableNTSCMode", pConfig->bEnableNTSCMode);
 	iniReader.WriteBoolean("MISC", "AshleyJPCameraAngles", pConfig->bAshleyJPCameraAngles);
 	iniReader.WriteInteger("MISC", "ViolenceLevelOverride", pConfig->iViolenceLevelOverride);
 	iniReader.WriteBoolean("MISC", "AllowSellingHandgunSilencer", pConfig->bAllowSellingHandgunSilencer);

--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -920,6 +920,7 @@ void Config::LogSettings()
 	spd::log()->info("| {:<30} | {:>15} |", "FixTurningSpeed", pConfig->bFixTurningSpeed ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "FixQTE", pConfig->bFixQTE ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "FixAshleyBustPhysics", pConfig->bFixAshleyBustPhysics ? "true" : "false");
+	spd::log()->info("| {:<30} | {:>15} |", "EnableNTSCMode", pConfig->bEnableNTSCMode ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "EnableFastMath", pConfig->bEnableFastMath ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "PrecacheModels", pConfig->bPrecacheModels ? "true" : "false");
 	spd::log()->info("+--------------------------------+-----------------+");
@@ -948,6 +949,7 @@ void Config::LogSettings()
 	spd::log()->info("| {:<30} | {:>15} |", "EnableDebugMenu", pConfig->bEnableDebugMenu ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "EnableModExpansion", pConfig->bEnableModExpansion ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "ForceETSApplyScale", pConfig->bForceETSApplyScale ? "true" : "false");
+	spd::log()->info("| {:<30} | {:>15} |", "EnableNTSCMode", pConfig->bEnableNTSCMode ? "true" : "false");
 	spd::log()->info("+--------------------------------+-----------------+");
 
 	// MEMORY

--- a/dllmain/Settings.h
+++ b/dllmain/Settings.h
@@ -108,7 +108,7 @@ public:
 	bool bEnableDebugMenu = false;
 	bool bEnableModExpansion = false;
 	bool bForceETSApplyScale = false;
-	bool bEnableNTSCMode = true;
+	bool bEnableNTSCMode = false;
 
 	// MEMORY
 	bool bAllowHighResolutionSFD = true;

--- a/dllmain/Settings.h
+++ b/dllmain/Settings.h
@@ -76,6 +76,7 @@ public:
 	bool bFixTurningSpeed = true;
 	bool bFixQTE = true;
 	bool bFixAshleyBustPhysics = true;
+	bool bFixMercsMode = true;
 	bool bEnableFastMath = true;
 	bool bPrecacheModels = false;
 
@@ -107,6 +108,7 @@ public:
 	bool bEnableDebugMenu = false;
 	bool bEnableModExpansion = false;
 	bool bForceETSApplyScale = false;
+	bool bEnableNTSCMode = true;
 
 	// MEMORY
 	bool bAllowHighResolutionSFD = true;

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -1057,6 +1057,19 @@ void cfgMenuRender()
 						ImGui::TextWrapped("Fixes difference between 30/60FPS on physics applied to Ashley.");
 					}
 
+					// FixMercsMode
+					{
+						ImGui_ColumnSwitch();
+
+						pConfig->HasUnsavedChanges |= ImGui::Checkbox("FixMercsMode", &pConfig->bFixMercsMode);
+
+						ImGui_ItemSeparator();
+
+						ImGui::Dummy(ImVec2(10, 10 * esHook._cur_monitor_dpi));
+						ImGui::TextWrapped("Fixes issues with adaptive difficulty gain and broken spawns when playing at 60fps in Mercenaries mode.");
+					}
+
+
 					// EnableFastMath
 					{
 						ImGui_ColumnSwitch();
@@ -1143,6 +1156,24 @@ void cfgMenuRender()
 						}
 						ImGui::PopItemWidth();
 						ImGui::EndDisabled();
+					}
+
+					// EnableNTSCMode
+					{
+						ImGui_ColumnSwitch();
+
+						if(ImGui::Checkbox("EnableNTSCMode", &pConfig->bEnableNTSCMode))
+						{
+							pConfig->HasUnsavedChanges = true;
+							NeedsToRestart = true;
+						}
+
+						ImGui_ItemSeparator();
+
+						ImGui::Dummy(ImVec2(10, 10 * esHook._cur_monitor_dpi));
+						ImGui::TextWrapped("Unlocks minor difficulty boosts previously exclusive to the North American console versions of RE4.");
+						ImGui::TextWrapped("Higher starting adaptive difficulty, more difficult Ada missions, and a more difficult Mercenaries village stage.");
+						ImGui::TextWrapped("Shooting gallery requirements are higher, and Easy difficulty is removed from the title menu.");
 					}
 
 					// AshleyJPCameraAngles

--- a/settings/settings.ini
+++ b/settings/settings.ini
@@ -237,7 +237,7 @@ AdaCostume = Normal
 ; Unlocks minor difficulty boosts previously exclusive to the NTSC console versions of RE4.
 ; Higher starting adaptive difficulty, more difficult Ada missions, and more difficult Mercenaries village stage.
 ; Shooting gallery requirements are higher, and Easy difficulty is removed from the title menu.
-UnlockNTSCMode = true
+EnableNTSCMode = false
 
 ; Unlocks the JP-only classic camera angles during Ashley's segment.
 AshleyJPCameraAngles = false

--- a/settings/settings.ini
+++ b/settings/settings.ini
@@ -203,6 +203,9 @@ FixQTE = true
 ; Fixes difference between 30/60FPS on physics applied to Ashley.
 FixAshleyBustPhysics = true
 
+; Fixes issues with adaptive difficulty gain and broken spawns when playing at 60fps in Mercenaries mode.
+FixMercsMode = true
+
 ; Replaces older math functions in the game with much more optimized equivalents.
 ; Experimental, can hopefully improve framerate in some areas that had dips.
 EnableFastMath = true
@@ -230,6 +233,11 @@ OverrideCostumes = false
 LeonCostume = Jacket
 AshleyCostume = Normal
 AdaCostume = Normal
+
+; Unlocks minor difficulty boosts previously exclusive to the NTSC console versions of RE4.
+; Higher starting adaptive difficulty, more difficult Ada missions, and more difficult Mercenaries village stage.
+; Shooting gallery requirements are higher, and Easy difficulty is removed from the title menu.
+UnlockNTSCMode = true
 
 ; Unlocks the JP-only classic camera angles during Ashley's segment.
 AshleyJPCameraAngles = false


### PR DESCRIPTION
Quoting my last post as a summary of what this is supposed to do:
>- Normal mode and Separate Ways start at 5500 difficulty instead of 3500.
>- Assignment Ada is fixed to 6500 difficulty instead of 4500.
>- Easy difficulty is removed as an option from the title menu.
>- Shooting range requirements are 3000 per bottle cap instead of 1000.
>- The village stage in Mercenaries has a unique dynamic difficulty mode. In PAL the difficulty is fixed at 5500, but in NTSC it's unlocked, and in addition you gain 30 difficulty points every second. ***This requires a 60fps fix, because it's just calling GameAddPoint(LVADD_TIMECOUNT) every frame in R400Main(). At 60fps, you gain difficulty twice as fast!

TODO:
- [ ] the note in the shooting range still says that bottle cap requirements are 1000. Not sure how we could fix this, sideloaded .MDT files?
- [x] need to test if the mercs mode 60fps fix also fixes the issues with glitched spawns mentioned in https://youtu.be/Z_w23LvouFQ?t=43 Edit: briefly tested this and I can't get these guys to spawn no matter how fast I jump through the window, even if I override player speed to do so instantly. Nor do these spawn in the Gamecube version, so something doesn't add up. Edit2: turns out this 'spawning glitch' is actually ancient, you can find posts on gamefaqs talking about it from 13 years ago, so has nothing to do with 60 fps. still would be interesting to figure out what's going on there.
 
There's probably a better way to ensure R400Main gets called only 30 times per second, but what I wrote at least works.

I couldn't figure out a way to GetBranchDestination j_R400Main, because the function is never called directly, as it's part of a table in st4_data_tbl in prologSt4(). So I just inlined the if at the top of R400Main.
